### PR TITLE
rewrite execute_log and calls to get rid of escaping issues

### DIFF
--- a/inaugurate
+++ b/inaugurate
@@ -162,18 +162,16 @@ function command_exists_only_user_visible {
 }
 
 function execute_log {
-    # eval "$1" >> "$SCRIPT_LOG_FILE" 2>&1 || error_exit "$2"
-
     local error="${@: -1}"
-    eval "${@:1:$#-1}" >> "$SCRIPT_LOG_FILE" 2>&1 || error_exit "$error"
+    "${@:1:$#-1}" >> "$SCRIPT_LOG_FILE" 2>&1 || error_exit "$error"
 }
 
 function download {
     {
         if command_exists wget; then
-            execute_log "wget -O $2 $1" "Could not download $1 using wget"
+            execute_log wget -O "$2" "$1" "Could not download $1 using wget"
         elif command_exists curl; then
-            execute_log "curl -o $2 $1" "Could not download $1 using curl"
+            execute_log curl -o "$2" "$1" "Could not download $1 using curl"
         else
             error_output "Could not find 'wget' nor 'curl' to download files. Exiting..."
             exit 1
@@ -302,14 +300,19 @@ EOF
     } >> "$SCRIPT_LOG_FILE" 2>&1 || error_exit "Could not create '$VENV_NAME' virtual environment, check log file for details: $SCRIPT_LOG_FILE"
 }
 
+function apt_update {
+    # sometimes, on a new debian machine, the first (and even 2nd) 'apt-get update' fails...
+    # so call is wrapped in a function
+    apt-get update || apt-get update
+}
 
 function install_inaugurate_deb {
     output "  * Debian-based system detected"
     output "  * updating apt cache"
     # sometimes, on a new debian machine, the first (and even 2nd) 'apt-get update' fails...
-    execute_log "apt-get update || apt-get update" "Could not update apt repository cache"
+    execute_log apt_update "Could not update apt repository cache"
     output "  * installing dependencies: $DEB_DEPENDENCIES"
-    execute_log "apt-get" "install" "-y" "$DEB_DEPENDENCIES" "Error installing dependencies via apt."
+    execute_log apt-get install -y $DEB_DEPENDENCIES "Error installing dependencies via apt."
     output "  * creating '$VENV_NAME' virtual environment"
     create_virtualenv
     for pkgName in $PIP_DEPENDENCIES
@@ -324,8 +327,8 @@ function install_inaugurate_deb {
 function install_inaugurate_rpm {
     output "  * RedHat-based system detected."
     output "  * installing dependencies: $RPM_DEPENDENCIES"
-    #execute_log "yum install -y epel-release" "Error installing epel-release via yum."
-    execute_log "yum" "install" "-y" "$RPM_DEPENDENCIES" "Error installing dependencies via yum."
+    #execute_log yum install -y epel-release "Error installing epel-release via yum."
+    execute_log yum install -y $RPM_DEPENDENCIES "Error installing dependencies via yum."
     output "  * creating '$VENV_NAME' virtual environment"
     create_virtualenv
     for pkgName in $PIP_DEPENDENCIES
@@ -340,7 +343,7 @@ function install_inaugurate_rpm {
 function install_inaugurate_dnf {
     output "  * RedHat-based system with 'dnf' detected."
     output "  * installing dependencies: yum python-dnf $RPM_DEPENDENCIES"
-    execute_log "dnf" "install" "-y" "yum" "python-dnf" "$RPM_DEPENDENCIES" "Error installing dependencies via yum."
+    execute_log dnf install -y yum python-dnf $RPM_DEPENDENCIES "Error installing dependencies via yum."
     output "  * creating '$VENV_NAME' virtual environment"
     create_virtualenv
     for pkgName in $PIP_DEPENDENCIES
@@ -365,7 +368,7 @@ function install_commandlinetools {
                sed -e 's/^ *//' |
                tr -d '\n')
         output "    -> installing: $PROD..."
-        execute_log "sudo" "-u" "$INAUGURATE_USER" "softwareupdate" "-i" "'$PROD'" "Could not install $PROD"
+        execute_log sudo -u "$INAUGURATE_USER" softwareupdate -i "$PROD" "Could not install $PROD"
         rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     else
         output "  - 'xcode' already present, skipping"
@@ -378,10 +381,10 @@ function install_inaugurate_mac_root {
     install_commandlinetools
     output "  * installing pip & virtualenv"
     if ! command_exists pip; then
-        execute_log "easy_install pip" "Could not install pip"
+        execute_log easy_install pip "Could not install pip"
     fi
     if ! command_exists virtualenv; then
-        execute_log "pip install virtualenv" "Could not install virtualenv via pip"
+        execute_log pip install virtualenv "Could not install virtualenv via pip"
     fi
 
     output "  * creating '$VENV_NAME' virtual environment"
@@ -578,7 +581,7 @@ function install_inaugurate_non_root_conda {
 
     if [ ! -e "$CONDA_INAUGURATE_ENV_EXE" ]; then
         output "  * creating '$CONDA_ENV_NAME' conda environment"
-        execute_log "$CONDA_ROOT_EXE" "create" "-y" "--name" "$CONDA_ENV_NAME" "python=$CONDA_PYTHON_VERSION" "Could not create conda environment."
+        execute_log "$CONDA_ROOT_EXE" create -y --name "$CONDA_ENV_NAME" "python=$CONDA_PYTHON_VERSION" "Could not create conda environment."
     else
         output "  - '$CONDA_ENV_NAME' conda environment already exists, not creating again"
     fi
@@ -590,7 +593,7 @@ function install_inaugurate_non_root_conda {
        output "    -> python already present in conda environment '$CONDA_ENV_NAME'"
      else
        output "    -> installing python (version $CONDA_PYTHON_VERSION) into conda environment '$CONDA_ENV_NAME'"
-       execute_log "$CONDA_ROOT_EXE" "install" "--name" "$CONDA_ENV_NAME" "-y" "python=$CONDA_PYTHON_VERSION" "Could not install python in conda environment."
+       execute_log "$CONDA_ROOT_EXE" install --name "$CONDA_ENV_NAME" -y "python=$CONDA_PYTHON_VERSION" "Could not install python in conda environment."
     fi
 
     # check conda dependencies
@@ -600,11 +603,11 @@ function install_inaugurate_non_root_conda {
             output "    -> package '$pkgName' already present in conda environment '$CONDA_ENV_NAME'"
          else
             output "    -> installing $pkgName into conda environment '$CONDA_ENV_NAME'"
-            execute_log "$CONDA_ROOT_EXE" "install" "--name" "$CONDA_ENV_NAME" "-y" "$pkgName" "Could not install $pkgName in conda environment."
+            execute_log "$CONDA_ROOT_EXE" install --name "$CONDA_ENV_NAME" -y "$pkgName" "Could not install $pkgName in conda environment."
          fi
     done
 
-    execute_log "source" "$INAUGURATE_CONDA_PATH/activate" "$CONDA_ENV_NAME" "Could not activate '$CONDA_ENV_NAME' conda environment"
+    execute_log source "$INAUGURATE_CONDA_PATH/activate" "$CONDA_ENV_NAME" "Could not activate '$CONDA_ENV_NAME' conda environment"
 
     for pkgName in $PIP_DEPENDENCIES
     do
@@ -613,11 +616,11 @@ function install_inaugurate_non_root_conda {
            output "    -> python package '$pkgName' already present in conda environment '$CONDA_ENV_NAME'"
         else
             output "    -> installing python package '$pkgName' into conda environment '$CONDA_ENV_NAME'"
-            execute_log "pip" "install" "-U" "$pkgName" "--upgrade-strategy" "only-if-needed" "Could not install $pkgName in conda environment"
+            execute_log pip install -U "$pkgName" --upgrade-strategy only-if-needed "Could not install $pkgName in conda environment"
         fi
 
     done
-    execute_log "source" "deactivate" "$CONDA_ENV_NAME" "Could not deactivate '$CONDA_ENV_NAME' conda environment"
+    execute_log source deactivate "$CONDA_ENV_NAME" "Could not deactivate '$CONDA_ENV_NAME' conda environment"
     link_conda_executables
     link_required_executables "$CONDA_INAUGURATE_ENV_PATH/bin" "$EXECUTABLES_TO_LINK"
     link_extra_executables "$CONDA_INAUGURATE_ENV_PATH/bin" "$EXTRA_EXECUTABLES"
@@ -702,7 +705,7 @@ EOF
 export PATH="$LOCAL_BIN_PATH:$INAUGURATE_BIN_PATH:$PATH"
 #export PATH="$LOCAL_BIN_PATH:$PATH"
 
-execute_log "echo Starting inaugurate bootstrap:" "'$(date)'" "Error"
+execute_log echo "Starting inaugurate bootstrap: $(date)" "Error"
 
 # prepare pip, conda and apt mirrors if necessary
 if [ "$CHINA" = true ]; then
@@ -818,7 +821,7 @@ else
     fi
 fi
 
-execute_log "echo Finished '$PROFILE_NAME' bootstrap: `date`" "Error"
+execute_log echo "Finished '$PROFILE_NAME' bootstrap: $(date)" "Error"
 
 #echo "INAUGURATE_PATH: $LOCAL_BIN_PATH"
 


### PR DESCRIPTION
See #3 

execute_log now accept a full bash command followed by a single-arg error message. Composite command no longer allowed (commandA || commandB); for this case, we use a function call.